### PR TITLE
Modify disp_eqns to support parameters

### DIFF
--- a/stack/maxima/contrib/linearalgebra.mac
+++ b/stack/maxima/contrib/linearalgebra.mac
@@ -1182,6 +1182,16 @@ SVD(M):= block([U,S,VT],
 /* Automatically formats a system of linear equations                            */
 /*********************************************************************************/
 
+/**
+ * Format expressions so that they can be printed as coefficients by wrapping sums
+ * and expressions with unary minus into brackets.
+ */
+format_as_coeff(expr):= block([ops, repr],
+  ops: errcatch(op(expr)),
+  repr: if emptyp(ops) or not elementp(first(ops), {"+", "-"}) then expr else simplode(["(", expr, ")"]),
+  return(repr)
+);
+
 /** 
  * Given a list of equations and a list of variables, produce TeX output that displays them as a system of equations.
  * Everything will be appropriately vertically aligned with leading ones and zeros removed appropriately.
@@ -1190,10 +1200,12 @@ SVD(M):= block([U,S,VT],
  * @param[list] vars A list of variables in the order that they should appear.
  * @return[string] TeX output for this system of equations
  */
-disp_eqns(eqns,vars):= block([s_in,s_first,one_zero_remover,delete_if_zero,m,n,p,pivot,ii,jj,v,a],
-  s_in(ex):= if ev(is(signum(ex)=-1),simp) then "-" else "+", /* returns the sign of a coefficient as a string, assuming 0 is positive */
-  s_first(ex):= if ev(is(signum(ex)=-1),simp) then "-" else "", /* Altered version of above that doesn't return + for leading coefficient */
-  one_zero_remover(ex):= if ev(is(ex=1) or is(ex=0),simp) then "" else if is(ex=-1) then "-" else ev(ex,simp), /* scrubs out unwanted ones and zeros */
+disp_eqns(eqns,vars):= block([is_neg,s_in,s_first,format_as_positive_coeff,one_zero_remover,delete_if_zero,m,n,p,pivot,ii,jj,v,a],
+  is_neg(ex) := ev(is(signum(ex)=-1),simp),  /* return true if ex is numerical and negative, false otherwise */
+  s_in(ex):= if is_neg(ex) then "-" else "+", /* returns the sign of a coefficient as a string, assuming 0 is positive */
+  s_first(ex):= if is_neg(ex) then "-" else "", /* Altered version of above that doesn't return + for leading coefficient */
+  format_as_positive_coeff(ex) := if is_neg(ex) then ev(abs(ex),simp) else format_as_coeff(ev(ex,simp)),
+  one_zero_remover(ex):= if ev(is(ex=1) or is(ex=0) or is(ex=-1),simp) then "" else format_as_positive_coeff(ev(ex,simp)), /* scrubs out unwanted ones and zeros */
   delete_if_zero(ex,var):= if is(ex=0) then "" else var, /* returns nothing if the coefficient is zero, otherwise returns the coefficient */
   n: length(eqns), /* n = number of equations */
   m: length(vars), /* m = number of variables */
@@ -1205,16 +1217,15 @@ disp_eqns(eqns,vars):= block([s_in,s_first,one_zero_remover,delete_if_zero,m,n,p
     v: vars[1], /* v is the variable we are looking at in this column */
     a: ev(coeff(lhs(eqns[ii]),v),simp), /* find coefficient of v */
     if is(a#0) and not(pivot) then pivot: true, /* If the coefficient is non-zero, we have found our pivot! */
-    /* p: append(p,[simplode([if pivot then s_first(a) else "",one_zero_remover(abs(a)),tex1(delete_if_zero(a,v))])]),  If this is a pivot, display normally, otherwise do nothing */
-    if pivot then p: append(p, [simplode([s_first(a),one_zero_remover(abs(a)),tex1(delete_if_zero(a,v))])]), 
+    if pivot then p: append(p, [simplode([s_first(a),one_zero_remover(a),tex1(delete_if_zero(a,v))])]), /* If this is a pivot, display normally, otherwise do nothing */
     for jj: 2 thru m do block(
       jj: ev(jj,simp),
       v: vars[jj],
       a: ev(coeff(lhs(eqns[ii]),v),simp),
-      if is(a#0) then p: append(p,[simplode(["& ", if pivot then s_in(a) else ""," & ",one_zero_remover(abs(a)),tex1(delete_if_zero(a,v))])]) else p: append(p,["& & "]),
+      if is(a#0) then p: append(p,[simplode(["& ", if pivot then s_in(a) else ""," & ",one_zero_remover(a),tex1(delete_if_zero(a,v))])]) else p: append(p,["& & "]),
       if is(a#0) and not(pivot) then pivot: true
-    ),/*TODO: what about 0=0? Currently displays as "=0"*/
-    if is(fullratsimp(lhs(eqns[ii]))=0) then p: append(p, ["0"]),
+    ),
+    if is(fullratsimp(lhs(eqns[ii]))=0) then p: append(p, ["0"]),  /* Display "0=0" properly */
     p: append(p,[simplode(["& = &",tex1(rhs(eqns[ii]))])]),
     if is(ii#n) then p: append(p,["\\\\"])
   ),

--- a/stack/maxima/contrib/linearalgebra_test.mac
+++ b/stack/maxima/contrib/linearalgebra_test.mac
@@ -391,5 +391,16 @@ s_test_case(SVD(matrix([1,1],[1,1])),[matrix([1/sqrt(2),1/sqrt(2)],[1/sqrt(2),-(
 s_test_case(SVD(matrix([1,1],[1,0],[0,1])),[matrix([sqrt(2)/sqrt(3),0,1/sqrt(3)],[1/sqrt(6),1/sqrt(2),-(1/sqrt(3))],[1/sqrt(6),-(1/sqrt(2)),-(1/sqrt(3))]),matrix([sqrt(3),0],[0,1],[0,0]),matrix([1/sqrt(2),1/sqrt(2)],[1/sqrt(2),-(1/sqrt(2))])]);
 s_test_case(SVD(matrix([1,1,0],[1,0,1])),[matrix([1/sqrt(2),1/sqrt(2)],[1/sqrt(2),-(1/sqrt(2))]),matrix([sqrt(3),0,0],[0,1,0]),matrix([sqrt(2)/sqrt(3),1/sqrt(6),1/sqrt(6)],[0,1/sqrt(2),-1/sqrt(2)],[1/sqrt(3),-(1/sqrt(3)),-(1/sqrt(3))])]);
 
+s_test_case(format_as_coeff(2), 2);
+s_test_case(format_as_coeff(-2), "(-2)");
+s_test_case(format_as_coeff(g-h), "(g-h)");
+s_test_case(format_as_coeff(g(x)), g(x));
+s_test_case(format_as_coeff(-g(x)), "(-g(x))");
+s_test_case(format_as_coeff(2*h), 2*h);
+s_test_case(format_as_coeff(-2*h), "(-2*h)");
+s_test_case(format_as_coeff(""), "");
+s_test_case(format_as_coeff("2"), "2");
+s_test_case(format_as_coeff(ev(2*k-2,simp)), "(2*k-2)");
 s_test_case(disp_eqns([2*x+y-z+(-3)*w = 7,-x-2*y+(-7)*w = -1,3*z = 0,x+w = 0,0 = 0],[x,y,z,w]),"\\begin{array} {rcrcrcrcr}2x& + & y& - & z& - & 3w& = &7\\\\-x& - & 2y& & & - & 7w& = &-1\\\\& & & & 3z& & & = &0\\\\x& & & & & + & w& = &0\\\\& & & & & & 0& = &0\\end{array}");
 s_test_case(mat_disp_eqns(matrix([2,1,-1,-3],[-1,-2,0,-7],[0,0,3,0],[1,0,0,1],[0,0,0,0]),matrix([7],[-1],[0],[0],[0]),[x,y,z,w]),"\\begin{array} {rcrcrcrcr}2x& + & y& - & z& - & 3w& = &7\\\\-x& - & 2y& & & - & 7w& = &-1\\\\& & & & 3z& & & = &0\\\\x& & & & & + & w& = &0\\\\& & & & & & 0& = &0\\end{array}");
+s_test_case(mat_disp_eqns(matrix([-2, k-1, -1],[0, 2*k+2, 0], [-1, k, -2]),matrix([k-1],[1],[-1]),[x,y,z]), "\begin{array} {rcrcrcr}-2x& + & (k-1)y& - & z& = &k-1\\&  & (2*k+2)y& & & = &1\\-x& + & ky& - & 2z& = &-1\end{array}")


### PR DESCRIPTION
Modify the `disp_eqns` function so that it can also display systems containing parameters, such as `kx + (k+1)y = 2`, which previous was displayed as `abs(k)x + abs(k+1)y = 2`.